### PR TITLE
IT-201 Change publish registry to private MapTiler NPM

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,10 +1,8 @@
 name: Release NPM private package
 
 on:
-  #release:
-  #  types: [ created ]
-  push:
-    branches: [ IT-201_publish-to-maptiler-npm ]
+  release:
+    types: [ created ]
 
 jobs:
   release:

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'latest'
 
@@ -24,10 +24,7 @@ jobs:
         run: npm config set //npm.maptiler.dev/:_authToken "${{ secrets.NPM_MAPTILER_TOKEN }}"
 
       - name: Install dependencies
-        run: npm install
-
-      - name: Build project
-        run: npm run build
+        run: npm ci
 
       - name: Publish package to MapTiler NPM
         run: npm publish

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: 18
 
       - name: Configure MapTiler NPM registry
         run: npm config set //npm.maptiler.dev/:_authToken "${{ secrets.NPM_MAPTILER_TOKEN }}"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Publish package to MapTiler NPM
         run: npm publish

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,33 @@
+name: Release NPM private package
+
+on:
+  #release:
+  #  types: [ created ]
+  push:
+    branches: [ IT-201_publish-to-maptiler-npm ]
+
+jobs:
+  release:
+    name: Release new version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'latest'
+
+      - name: Configure MapTiler NPM registry
+        run: npm config set //npm.maptiler.dev/:_authToken "${{ secrets.NPM_MAPTILER_TOKEN }}"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Publish package to MapTiler NPM
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "restricted",
-    "registry": "https://npm.pkg.github.com/maptiler"
+    "registry": "https://npm.maptiler.dev/"
   },
   "peerDependencies": {
     "bootstrap": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/styles",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Visual front-end framework of MapTiler brand based on Bootstrap",
   "author": "MapTiler Team",
   "repository": {


### PR DESCRIPTION
IT-201

## Objective
Change publish registry from GitHub to private MapTiler NPM registry https://npm.maptiler.dev/

## Description
- Add step configuration for MapTiler NPM registry (Remove old authentication)
- Change publishConfig

## Acceptance
Testing on push to this branch.
Package should be visible in MapTiler NPM https://npm.maptiler.dev/ https://npm.maptiler.dev/-/web/detail/@maptiler/styles
Published the newest version `v2.0.0` and the last released version `v1.1.0`
